### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ $ npm install dmd-kramdown-plugin --save-dev
 Then pass the plug-in name to `jsdoc2md` or `dmd`:
 
 ```
-$ jsdoc2md --plugin dmd-kramdown-plugin mySrcFiles/*.js
+$ jsdoc2md --plugin dmd-kramdown-plugin --src mySrcFiles/*.js
 ```


### PR DESCRIPTION
careful here.. 

`--plugin` accept multiple plugin args so the command `jsdoc2md --plugin dmd-kramdown-plugin mySrcFiles/*.js` is passing the plugin plus those source files as plugins.. 

use the `--src` option explicitly in cases like this when it's not clear where the list of source files begins.. i may need need to improve the docs..
